### PR TITLE
pre match user to cohort

### DIFF
--- a/packages/ab-testing/__tests__/index.test.ts
+++ b/packages/ab-testing/__tests__/index.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import * as ABTesting from '../src';
+import Experiments, { ABTestingConfig } from '../src';
 import { hashObject } from '@appannie/ab-testing-hash-object';
 
 describe('ab-testing module', () => {
     const salt = '4a9120a277117afeade34305c258a2f1';
-    const config: ABTesting.ABTestingConfig = {
+    const config: ABTestingConfig = {
         version: '1.0',
         experiments: [
             {
@@ -63,52 +63,52 @@ describe('ab-testing module', () => {
 
     it('match cohorts', () => {
         expect(
-            new ABTesting.Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
+            new Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
                 'experiment_1'
             )
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
+            new Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
                 'experiment_1'
             )
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, user_type: 'free' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, user_type: 'intelligence' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email: 'control@example.com' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email: 'control@a.com' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email_domain: 'example.com' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email_domain: 'a.com' }, config.salt)
@@ -119,7 +119,7 @@ describe('ab-testing module', () => {
                 .fill(0)
                 .map((_, i) => [
                     i + 3,
-                    new ABTesting.Experiments(
+                    new Experiments(
                         config,
                         i + 3,
                         hashObject({ user_id: i + 3 }, config.salt)
@@ -128,52 +128,52 @@ describe('ab-testing module', () => {
         ).toMatchSnapshot();
 
         expect(
-            new ABTesting.Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
+            new Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
                 'experiment_2'
             )
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
+            new Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
                 'experiment_2'
             )
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, user_type: 'free' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, user_type: 'intelligence' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email: 'control@example.com' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email: 'control@a.com' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('test_force_include');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email_domain: 'example.com' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('control');
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email_domain: 'a.com' }, config.salt)
@@ -184,7 +184,7 @@ describe('ab-testing module', () => {
                 .fill(0)
                 .map((_, i) => [
                     i + 3,
-                    new ABTesting.Experiments(
+                    new Experiments(
                         config,
                         i + 3,
                         hashObject({ user_id: i + 3 }, config.salt)
@@ -193,7 +193,7 @@ describe('ab-testing module', () => {
         ).toMatchSnapshot();
 
         expect(
-            new ABTesting.Experiments(
+            new Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email_domain: 'example.com' }, config.salt)
@@ -202,7 +202,7 @@ describe('ab-testing module', () => {
     });
 
     it('match results is cached', () => {
-        const experiment = new ABTesting.Experiments(
+        const experiment = new Experiments(
             config,
             1,
             hashObject({ user_id: 1, user_type: 'intelligence' }, config.salt)

--- a/packages/ab-testing/__tests__/index.test.ts
+++ b/packages/ab-testing/__tests__/index.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/camelcase */
-import Experiments, { ABTestingConfig } from '../src';
+import * as ABTesting from '../src';
 import { hashObject } from '@appannie/ab-testing-hash-object';
 
 describe('ab-testing module', () => {
     const salt = '4a9120a277117afeade34305c258a2f1';
-    const config: ABTestingConfig = {
+    const config: ABTesting.ABTestingConfig = {
         version: '1.0',
         experiments: [
             {
@@ -63,52 +63,52 @@ describe('ab-testing module', () => {
 
     it('match cohorts', () => {
         expect(
-            new Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
+            new ABTesting.Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
                 'experiment_1'
             )
         ).toEqual('control');
         expect(
-            new Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
+            new ABTesting.Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
                 'experiment_1'
             )
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, user_type: 'free' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, user_type: 'intelligence' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('control');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email: 'control@example.com' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email: 'control@a.com' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('control');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email_domain: 'example.com' }, config.salt)
             ).getCohort('experiment_1')
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 2,
                 hashObject({ user_id: 2, email_domain: 'a.com' }, config.salt)
@@ -119,7 +119,7 @@ describe('ab-testing module', () => {
                 .fill(0)
                 .map((_, i) => [
                     i + 3,
-                    new Experiments(
+                    new ABTesting.Experiments(
                         config,
                         i + 3,
                         hashObject({ user_id: i + 3 }, config.salt)
@@ -128,52 +128,52 @@ describe('ab-testing module', () => {
         ).toMatchSnapshot();
 
         expect(
-            new Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
+            new ABTesting.Experiments(config, 1, hashObject({ user_id: 1 }, config.salt)).getCohort(
                 'experiment_2'
             )
         ).toEqual('control');
         expect(
-            new Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
+            new ABTesting.Experiments(config, 2, hashObject({ user_id: 2 }, config.salt)).getCohort(
                 'experiment_2'
             )
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, user_type: 'free' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('control');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, user_type: 'intelligence' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email: 'control@example.com' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('control');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email: 'control@a.com' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('test_force_include');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email_domain: 'example.com' }, config.salt)
             ).getCohort('experiment_2')
         ).toEqual('control');
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email_domain: 'a.com' }, config.salt)
@@ -184,7 +184,7 @@ describe('ab-testing module', () => {
                 .fill(0)
                 .map((_, i) => [
                     i + 3,
-                    new Experiments(
+                    new ABTesting.Experiments(
                         config,
                         i + 3,
                         hashObject({ user_id: i + 3 }, config.salt)
@@ -193,11 +193,21 @@ describe('ab-testing module', () => {
         ).toMatchSnapshot();
 
         expect(
-            new Experiments(
+            new ABTesting.Experiments(
                 config,
                 1,
                 hashObject({ user_id: 1, email_domain: 'example.com' }, config.salt)
             ).getCohort('experiment_3')
         ).toEqual('control');
+    });
+
+    it('match results is cached', () => {
+        const experiment = new ABTesting.Experiments(
+            config,
+            1,
+            hashObject({ user_id: 1, user_type: 'intelligence' }, config.salt)
+        );
+        expect(experiment.getCohort('experiment_2')).toEqual('test_force_include');
+        expect(experiment.getCohort('experiment_2')).toEqual('test_force_include');
     });
 });

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -71,6 +71,7 @@ export class Experiments {
         if (!(experimentName in this.matchedCohorts)) {
             const experimentConfig: Experiment = this.config[experimentName];
             if (experimentConfig == null) {
+                console.error(`unrecognized ab testing experiment name: ${experimentName}`);
                 this.matchedCohorts[experimentName] = 'control';
             } else {
                 this.matchedCohorts[experimentName] = matchUserCohort(

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -25,42 +25,62 @@ function getModuloValue(experiment: string, userId: number): number {
     return crc32.calculate(String(userId), crc32.calculate(experiment)) % 100;
 }
 
+function matchUserCohort(
+    experimentConfig: Experiment,
+    userId: number,
+    userProfile: { [s: string]: string }
+): string {
+    const userSegmentNum = getModuloValue(experimentConfig.name, userId);
+    let allocatedCohort = 'control';
+    for (const cohort of experimentConfig.cohorts) {
+        if (cohort.force_include) {
+            for (const key in cohort.force_include) {
+                if (cohort.force_include[key].includes(userProfile[key])) {
+                    return cohort.name;
+                }
+            }
+        }
+        if (allocatedCohort === 'control') {
+            for (const allocation of cohort.allocation || []) {
+                if (allocation[0] <= userSegmentNum && userSegmentNum < allocation[1]) {
+                    allocatedCohort = cohort.name;
+                }
+            }
+        }
+    }
+    return allocatedCohort;
+}
+
 export class Experiments {
-    config: ABTestingConfig;
+    config: { [experimentName: string]: Experiment };
     userId: number;
     userProfile: { [s: string]: string };
+    matchedCohorts: { [experimentName: string]: string };
 
     constructor(config: ABTestingConfig, userId: number, userProfile: { [s: string]: string }) {
-        this.config = config;
+        this.config = {};
         this.userId = userId;
         this.userProfile = userProfile;
+        this.matchedCohorts = {};
+        for (const experimentConfig of config.experiments) {
+            this.config[experimentConfig.name] = experimentConfig;
+        }
     }
 
     getCohort = (experimentName: string): string => {
-        const experimentConfig = this.config.experiments.find(e => e.name === experimentName);
-        if (!experimentConfig) {
-            console.error(`unrecognized ab testing experiment name: ${experimentName}`);
-            return 'control';
-        }
-        const userSegmentNum = getModuloValue(experimentName, this.userId);
-        let allocatedCohort = 'control';
-        for (const cohort of experimentConfig.cohorts) {
-            if (cohort.force_include) {
-                for (const key in cohort.force_include) {
-                    if (cohort.force_include[key].includes(this.userProfile[key])) {
-                        return cohort.name;
-                    }
-                }
-            }
-            if (allocatedCohort === 'control') {
-                for (const allocation of cohort.allocation || []) {
-                    if (allocation[0] <= userSegmentNum && userSegmentNum < allocation[1]) {
-                        allocatedCohort = cohort.name;
-                    }
-                }
+        if (!(experimentName in this.matchedCohorts)) {
+            const experimentConfig: Experiment = this.config[experimentName];
+            if (experimentConfig == null) {
+                this.matchedCohorts[experimentName] = 'control';
+            } else {
+                this.matchedCohorts[experimentName] = matchUserCohort(
+                    experimentConfig,
+                    this.userId,
+                    this.userProfile
+                );
             }
         }
-        return allocatedCohort;
+        return this.matchedCohorts[experimentName];
     };
 }
 

--- a/packages/react-ab-testing/__tests__/index.test.tsx
+++ b/packages/react-ab-testing/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import hashObject from '@appannie/ab-testing-hash-object';
 import { ABTestingController, useCohortOf } from '../src';
 
 describe('AB Testing', () => {
+    const salt = '4a9120a277117afeade34305c258a2f1';
     const config: ABTestingConfig = {
         version: '1.0',
         experiments: [
@@ -19,24 +20,18 @@ describe('AB Testing', () => {
                             [0, 10],
                             [90, 100],
                         ],
-                        force_include: {},
                     },
                     {
                         name: 'test_force_include',
-                        force_include: {
-                            '559585298de65441d096a03315c848e25a5ceff9eea48bf5041e24ea4d481022': [
-                                '6b1bb552ddd9efa8188da1366386d303543a6de703d5ba8415f7a00b60e1eaea',
-                            ],
-                            '6ac346cad30f3196adbe9cb6f546cb8115b9f8998d1346b004481d1a6eb102f9': [
-                                '7ff9a510c4f06d3e30e21308ccf043d909f683e9b573929215c05c3e6f852c00',
-                            ],
-                            '0a107badb326491ebb2a4483d5b1d86e87c98ea21a34c29c32bf6205d0245e6e': [
-                                '2b474d6af1a14715371d450aedce427cfff78f6b9d2ceec5bf1321169206e046',
-                            ],
-                            '7aa814f6be9d13c1fc70d8d32a34dcce812381be4754c711540310b256e10e80': [
-                                '2c12caae54b0922eeba0560087d59d6a012eb431146e761c97787a28ca907625',
-                            ],
-                        },
+                        force_include: hashObject(
+                            {
+                                user_id: [1],
+                                user_type: ['free'],
+                                email: ['control@example.com'],
+                                email_domain: ['example.com'],
+                            },
+                            salt
+                        ),
                     },
                 ],
             },
@@ -50,29 +45,23 @@ describe('AB Testing', () => {
                             [10, 20],
                             [80, 90],
                         ],
-                        force_include: {},
                     },
                     {
                         name: 'test_force_include',
-                        force_include: {
-                            '559585298de65441d096a03315c848e25a5ceff9eea48bf5041e24ea4d481022': [
-                                'd35efdfffec2f18661a2fdce592ba8237c8f12753bfaf3f3e7456304393764b8',
-                            ],
-                            '6ac346cad30f3196adbe9cb6f546cb8115b9f8998d1346b004481d1a6eb102f9': [
-                                '26e0a9e7e1dfe33ce15ef16cb7a1e0086ee7916ec10eb52a4a8fffe00ae3a40c',
-                            ],
-                            '0a107badb326491ebb2a4483d5b1d86e87c98ea21a34c29c32bf6205d0245e6e': [
-                                'ea799fdde1713dbf6bb5c666c3117ab8d19254966997fa413394c0b33ca5bab6',
-                            ],
-                            '7aa814f6be9d13c1fc70d8d32a34dcce812381be4754c711540310b256e10e80': [
-                                '10a3c3b449ed70682d756f3f6b980595ebc284819250730a4ffc184e08c0b3f6',
-                            ],
-                        },
+                        force_include: hashObject(
+                            {
+                                user_id: [2],
+                                user_type: ['intelligence'],
+                                email: ['control@a.com'],
+                                email_domain: ['a.com'],
+                            },
+                            salt
+                        ),
                     },
                 ],
             },
         ],
-        salt: '4a9120a277117afeade34305c258a2f1',
+        salt,
     };
 
     it('getCohort without context', () => {


### PR DESCRIPTION
As an alternative way of performance optimization (compare with https://github.com/BananaWanted/ab-testing/pull/5), pre-match user to cohorts for all experiments.