### PR TITLE
force using js impl of crc32c

### DIFF
--- a/@types/fast-crc32c/index.d.ts
+++ b/@types/fast-crc32c/index.d.ts
@@ -1,3 +1,7 @@
 declare module 'fast-crc32c' {
     export function calculate(data: string | Buffer, initial?: number): number;
 }
+
+declare module 'fast-crc32c/impls/js_crc32c' {
+    export * from 'fast-crc32c';
+}

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -1,4 +1,4 @@
-import crc32 from 'fast-crc32c';
+import crc32 from 'fast-crc32c/impls/js_crc32c';
 
 type ForceInclude = {
     [key: string]: string[];


### PR DESCRIPTION
The `fast-crc32c` module is using `require` to decide the implementation to use, which doesn't work in the browser.