### PR TITLE
move react to peerDependencies

### DIFF
--- a/packages/react-ab-testing/package.json
+++ b/packages/react-ab-testing/package.json
@@ -17,8 +17,10 @@
   },
   "keywords": [],
   "dependencies": {
-    "@appannie/ab-testing": "^1.0.3",
-    "react": "^16.12.0"
+    "@appannie/ab-testing": "^1.0.3"
+  },
+  "peerDependencies": {
+    "react": "^16.0.0"
   },
   "devDependencies": {
     "@appannie/ab-testing-hash-object": "^1.0.3",
@@ -31,6 +33,7 @@
     "eslint-plugin-jest": "^23.6.0",
     "eslint-plugin-react": "^7.18.3",
     "eslint-plugin-react-hooks": "^2.3.0",
-    "react-test-renderer": "^16.12.0"
+    "react-test-renderer": "^16.12.0",
+    "react": "^16.12.0"
   }
 }


### PR DESCRIPTION
move react to peerDependencies otherwise it fails any project installed with a different react version.