### PR TITLE
remove polyfill

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     preset: 'ts-jest',
+    setupFiles: ['./jest.setup.js'],
     testEnvironment: 'node',
     testPathIgnorePatterns: ['/node_modules/', '/output/'],
     collectCoverage: true,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+require('ts-polyfill');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint-staged": "^10.0.7",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.0",
+    "ts-polyfill": "^3.8.2",
     "typescript": "^3.7.5"
   },
   "lint-staged": {

--- a/packages/ab-testing-hash-object/package.json
+++ b/packages/ab-testing-hash-object/package.json
@@ -17,8 +17,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "create-hash": "^1.2.0",
-    "ts-polyfill": "^3.7.5"
+    "create-hash": "^1.2.0"
   },
   "devDependencies": {
     "@types/create-hash": "^1.2.2"

--- a/packages/ab-testing-hash-object/src/index.ts
+++ b/packages/ab-testing-hash-object/src/index.ts
@@ -1,4 +1,3 @@
-import 'ts-polyfill/lib/es2019-object';
 import createHash from 'create-hash';
 
 export function hashWithSalt(value: unknown, salt: string): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,6 +2438,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+core-js@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
+  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -7439,6 +7444,13 @@ ts-jest@^25.2.0:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
+
+ts-polyfill@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/ts-polyfill/-/ts-polyfill-3.8.2.tgz#7375c6b6a4ae074af4f6200ff6c0d32dbbd113cb"
+  integrity sha512-x0M4kx+FObO88sedZ1zld+YX+GvcgaYSVnHspNftI4GRT86FTBy41O89ztKfvue0XtaKpb8WBpPZsh82hy3Ncw==
+  dependencies:
+    core-js "^3.6.4"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,11 +2438,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
-  integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -7444,13 +7439,6 @@ ts-jest@^25.2.0:
     resolve "1.x"
     semver "^5.5"
     yargs-parser "10.x"
-
-ts-polyfill@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/ts-polyfill/-/ts-polyfill-3.7.5.tgz#c8d0fb9e771857cd0c910f049f06adb5c94c0686"
-  integrity sha512-KJQ+5JQQoiy7LN1K7SQZj8+J5k4zDzZp20KjaR4s4M93eIbHT760IhoVcQBgwrgEJPip0InaxBTP0JWZ6cNopQ==
-  dependencies:
-    core-js "^3.6.4"
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.10.0"


### PR DESCRIPTION
- Removed `ts-polyfill` from dependencies, so library users need to set up their own polyfill otherwise this library may not working correctly.

- For UT (since we support both node 10 & 12), `ts-polyfill` is still used to simulate a polyfilled environment.