### PR TITLE
fixing missing readme in npm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,7 +31,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
       - name: Copy README.me
         run: |
-          for i in packages/*; do echo cp README.md $i; done
+          for i in packages/*; do cp README.md $i; done
       - name: Publish to NPM
         run: |
           yarn install


### PR DESCRIPTION
an awkward fix: we're not pushing the README to npm pages 🤦‍♂️