### PR TITLE
remove coveralls for python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,9 +79,6 @@ jobs:
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test
         working-directory: ./packages/py-ab-testing
-        env:
-          COVERALLS_PARALLEL: true
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
           pip install -r requirements.txt
           pip install -e .
@@ -89,16 +86,15 @@ jobs:
             --cov-config=.coveragerc \
             --cov=ABTesting \
             --cov-branch \
-            --cov-report=html:cov.html \
+            --cov-report=html:coverage.html \
+            --cov-report=xml:coverage.xml \
             --cov-report=term-missing:skip-covered \
             tests
-          coveralls
 
   finish_coveralls:
     runs-on: ubuntu-latest
     needs:
       - js
-      - py
     steps:
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/packages/py-ab-testing/ABTesting/controller.py
+++ b/packages/py-ab-testing/ABTesting/controller.py
@@ -1,14 +1,14 @@
 import logging
 from typing import Union, Dict
 
-from crc32c import crc32
+from crc32c import crc32c
 
 logger = logging.getLogger(__name__)
 
 
 def get_modulo_value(experiment, user_id):
     # type: (str, Union[str, int]) -> int
-    return crc32(str(user_id).encode(), crc32(experiment.encode())) % 100
+    return crc32c(str(user_id).encode(), crc32c(experiment.encode())) % 100
 
 
 def match_user_cohort(

--- a/packages/py-ab-testing/requirements.txt
+++ b/packages/py-ab-testing/requirements.txt
@@ -1,5 +1,6 @@
 pytest>=4.6,<=4.7
 pytest-cov>=2.8,<=3
-coveralls>=1.11,<=2
 snapshottest<1.0
+# later version of fastdiff stops working with py27, required by snapshottest
+fastdiff==0.2.0
 mock<4.0


### PR DESCRIPTION
remove coveralls for python since it's not working (isn't uploading anything) and is causing failure in forked PRs