### PR TITLE
Drop ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,3 @@
-<!-- TOC -->
-
-- [AB Testing](#ab-testing)
-- [Terms](#terms)
-- [Package API References](#package-api-references)
-    - [For React: `@appannie/react-ab-testing`](#for-react-appanniereact-ab-testing)
-        - [Installation](#installation)
-        - [Usage](#usage)
-    - [For Vanilla Javascript: `@appannie/ab-testing`](#for-vanilla-javascript-appannieab-testing)
-        - [Installation](#installation-1)
-        - [Usage](#usage-1)
-    - [Javascript Hashing Utils `@appannie/ab-testing-hash-object`](#javascript-hashing-utils-appannieab-testing-hash-object)
-        - [Installation](#installation-2)
-        - [Usage](#usage-2)
-    - [For Python: `py-ab-testing`](#for-python-py-ab-testing)
-        - [Installation](#installation-3)
-        - [Usage](#usage-3)
-        - [Configration Hashing](#configration-hashing)
-            - [Prepare config file BEFORE make it public](#prepare-config-file-before-make-it-public)
-            - [In runtime](#in-runtime)
-- [Configuration File Reference](#configuration-file-reference)
-    - [Configuration File Hashing and Protecting private information](#configuration-file-hashing-and-protecting-private-information)
-    - [Example configuration and common use case](#example-configuration-and-common-use-case)
-        - [Excluding a user from an experiment](#excluding-a-user-from-an-experiment)
-        - [Internal whitelist](#internal-whitelist)
-- [Credits](#credits)
-
-<!-- /TOC -->
-
 # AB Testing
 
 [![CI](https://github.com/appannie/ab-testing/workflows/CI/badge.svg)](https://github.com/appannie/ab-testing/actions?query=workflow%3ACI)


### PR DESCRIPTION
We don't need to maintain our ToC anymore since GitHub has its own ToC.

<img width="341" alt="image" src="https://user-images.githubusercontent.com/8186898/118740752-34bb9c80-b87f-11eb-94dd-10eea774de09.png">
