### PR TITLE
fix publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,8 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
-          ref: ${{ github.event.release.target_commitish }}
+          ref: master
       - name: Remove the triggering release
         run: |
           curl -XDELETE \
@@ -22,16 +21,16 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - run: |
-          git config --global user.name "github-actions[bot]"
       - name: Copy README.me
         run: |
           for i in packages/*; do cp README.md $i; done
+      - run: |
+          git config --global user.name "github-actions[bot]"
       - name: Publish to NPM
         run: |
           yarn install


### PR DESCRIPTION
Github Actions now has builtin auth support via the `GITHUB_TOKEN` variable ([doc](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)).

We used to use our own PAT for pushing the release info. Apparently, the PAT approach has stopped working just now. It's time to adopt the new workflow.

Besides using `GITHUB_TOKEN`, I also simplified the workflow a little bit. In the old version, we were passing `${{ github.event.release.target_commitish }}` to the checkout action to allow publishing an arbitrary commit. It turns out we didn't need this feature at all. Therefore I'm removing it for simplicity.
 
sample workflow output can be found here https://github.com/ZigZagT/ab-testing/runs/3073667970?check_suite_focus=true
(note NPM step is expected to fail with 401 as its a forked repo)