### PR TITLE
fix publish action use GH environment and access token 

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,12 +6,14 @@ on:
 
 jobs:
   publish:
+    environment: publish
     if: "github.event.release.tag_name == 'major' || github.event.release.tag_name == 'minor' || github.event.release.tag_name == 'patch'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
           ref: master
+          token: ${{ secrets.DEPLOY_GITHUB_ACCESS_TOKEN }}
       - name: Remove the triggering release
         run: |
           curl -XDELETE \


### PR DESCRIPTION
attempt to fix the broken publish action.

GitHub changed it's way passing environment variables to the actions. We need to update the configs accordingly.

More about environment configs: https://docs.github.com/en/actions/reference/environments