### PR TITLE
remove referring Github Environments

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   publish:
-    environment: publish
     if: "github.event.release.tag_name == 'major' || github.event.release.tag_name == 'minor' || github.event.release.tag_name == 'patch'"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removing the Environments dependency since the repo doesn't have access to this feature.

We'll rely on the `DEPLOY_GITHUB_ACCESS_TOKEN` [repository secret](https://github.com/appannie/ab-testing/settings/secrets/actions).  