### PR TITLE
feat: add capability to add fields to allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,26 +3,26 @@
 - [AB Testing](#ab-testing)
 - [Terms](#terms)
 - [Package API References](#package-api-references)
-    - [For React: `@appannie/react-ab-testing`](#for-react-appanniereact-ab-testing)
-        - [Installation](#installation)
-        - [Usage](#usage)
-    - [For Vanilla Javascript: `@appannie/ab-testing`](#for-vanilla-javascript-appannieab-testing)
-        - [Installation](#installation-1)
-        - [Usage](#usage-1)
-    - [Javascript Hashing Utils `@appannie/ab-testing-hash-object`](#javascript-hashing-utils-appannieab-testing-hash-object)
-        - [Installation](#installation-2)
-        - [Usage](#usage-2)
-    - [For Python: `py-ab-testing`](#for-python-py-ab-testing)
-        - [Installation](#installation-3)
-        - [Usage](#usage-3)
-        - [Configration Hashing](#configration-hashing)
-            - [Prepare config file BEFORE make it public](#prepare-config-file-before-make-it-public)
-            - [In runtime](#in-runtime)
+  - [For React: `@appannie/react-ab-testing`](#for-react-appanniereact-ab-testing)
+    - [Installation](#installation)
+    - [Usage](#usage)
+  - [For Vanilla Javascript: `@appannie/ab-testing`](#for-vanilla-javascript-appannieab-testing)
+    - [Installation](#installation-1)
+    - [Usage](#usage-1)
+  - [Javascript Hashing Utils `@appannie/ab-testing-hash-object`](#javascript-hashing-utils-appannieab-testing-hash-object)
+    - [Installation](#installation-2)
+    - [Usage](#usage-2)
+  - [For Python: `py-ab-testing`](#for-python-py-ab-testing)
+    - [Installation](#installation-3)
+    - [Usage](#usage-3)
+    - [Configration Hashing](#configration-hashing)
+      - [Prepare config file BEFORE make it public](#prepare-config-file-before-make-it-public)
+      - [In runtime](#in-runtime)
 - [Configuration File Reference](#configuration-file-reference)
-    - [Configuration File Hashing and Protecting private information](#configuration-file-hashing-and-protecting-private-information)
-    - [Example configuration and common use case](#example-configuration-and-common-use-case)
-        - [Excluding a user from an experiment](#excluding-a-user-from-an-experiment)
-        - [Internal whitelist](#internal-whitelist)
+  - [Configuration File Hashing and Protecting private information](#configuration-file-hashing-and-protecting-private-information)
+  - [Example configuration and common use case](#example-configuration-and-common-use-case)
+    - [Excluding a user from an experiment](#excluding-a-user-from-an-experiment)
+    - [Internal whitelist](#internal-whitelist)
 - [Credits](#credits)
 
 <!-- /TOC -->
@@ -39,7 +39,7 @@ The AB Testing library segmentating users under different "[cohorts](#terms)", s
 
 There're 2 ways of segmentation:
 
-1. Percentage based segmentation: Randomly allocate certain percent of user to a "[cohort](#terms)". The allocation algorithm guarantees to produce stable results within a single [experiment](#terms), and produce a different set of users for another [experiment](#terms) in a random way. Take a look at this example: `first 25% users`, it will always result into the same group of users in [experiment](#terms) `A`, but results in another completely different group of users for [experiment](#terms) `B`.
+1. Percentage based segmentation: Randomly allocate certain percent of user to a "[cohort](#terms)". The allocation algorithm guarantees to produce stable results within a single [experiment](#terms), and produce a different set of users for another [experiment](#terms) in a random way. You can also further filter the user set using the key `allocation_criteria`. Take a look at this example: `first 25% users`, it will always result into the same group of users in [experiment](#terms) `A`, but results in another completely different group of users for [experiment](#terms) `B`.
 2. User profile based segmentation: Manually assign a specific group of users to a cohort. This can be used to achieve features like "expose a new feature to the company emplyees for internal testing". Note the profile based segmentation works independently from the percentage based method. They doesn't interfere each other.
 
 The segmentation decisions are made base on a configuration file. The file should be `json` formated and hosted centralized place. More details about the configuration file below.
@@ -313,6 +313,12 @@ controller = ABTestingController(config, user.id, hashed_user_profile)
                     allocation: [
                         [0, 25]
                     ],
+                    // The allocation_criteria key allows us to further filter the set of users by enforcing 
+                    // a criteria that must be valid before the cohort is approved. In this case, 
+                    // the user must have an email domain of data.ai or appannie.com.
+                    allocation_criteria: {
+                        email_domain: ['appannie.com', 'data.ai']
+                    }
                 },
                 {
                     // "control" is the default cohort. All experiments always have a control cohort.
@@ -325,7 +331,7 @@ controller = ABTestingController(config, user.id, hashed_user_profile)
 }
 ```
 
-At App Annie, we're maintaining this configuration in yaml format to reduce the syntax noise. We have an automated CI task to encode/encrypt and push the final configuration to a public S3 bucket from where our SDK retrieve the configuration.
+At Data AI, we're maintaining this configuration in yaml format to reduce the syntax noise. We have an automated CI task to encode/encrypt and push the final configuration to a public S3 bucket from where our SDK retrieve the configuration.
 
 ## Configuration File Hashing and Protecting private information
 
@@ -378,13 +384,13 @@ experiments:
           - name: control
           - name: cohort_A
             force_include:
-                # Force all App Annie user under the given cohort
+                # Force all Data AI user under the given cohort
                 email_domain:
                     - appannie.com
 ```
 
 # Credits
 
-Made with ❤️ by [Zhang Tao](https://github.com/ZigZagT) and [Simon Boudrias](https://github.com/SBoudrias) from the App Annie Beijing office.
+Made with ❤️ by [Zhang Tao](https://github.com/ZigZagT) and [Simon Boudrias](https://github.com/SBoudrias) from the Data AI Beijing office.
 
 Available for public use under the MIT license.

--- a/packages/ab-testing/__tests__/functions.test.ts
+++ b/packages/ab-testing/__tests__/functions.test.ts
@@ -24,22 +24,17 @@ describe('test validateAllocation func', () => {
     };
 
     it('passes an allocation if the user segment is within the valid range', () => {
-        expect(
-            validateAllocation(validCohort, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
-        ).toBe(true);
+        expect(validateAllocation(validCohort, hashObject({ user_id: 2 }, salt), 51)).toBe(true);
     });
     it('fails an allocation if the user segment is not within the valid range', () => {
-        expect(
-            validateAllocation(invalidCohort, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
-        ).toBe(false);
+        expect(validateAllocation(invalidCohort, hashObject({ user_id: 2 }, salt), 51)).toBe(false);
     });
     it('V2 - passes an allocation with fields if the user satisfies field requirements', () => {
         expect(
             validateAllocation(
                 fieldCohortV2,
                 hashObject({ user_id: 2, email_domain: 'data.ai' }, salt),
-                'experiment_1',
-                2
+                51
             )
         ).toBe(true);
     });
@@ -48,8 +43,7 @@ describe('test validateAllocation func', () => {
             validateAllocation(
                 fieldCohortV2,
                 hashObject({ user_id: 2, email_domain: 'google.ca' }, salt),
-                'experiment_1',
-                2
+                51
             )
         ).toBe(false);
     });

--- a/packages/ab-testing/__tests__/functions.test.ts
+++ b/packages/ab-testing/__tests__/functions.test.ts
@@ -1,0 +1,80 @@
+import { hashObject } from '@appannie/ab-testing-hash-object';
+import { validateAllocation, Cohort } from '../src';
+
+describe('test validateAllocation func', () => {
+    const salt = '4a9120a277117afeade34305c258a2f1';
+    const validCohort: Cohort = {
+        name: 'test_cohort',
+        allocation: [[50, 100]],
+    };
+    const invalidCohort: Cohort = {
+        name: 'test_cohort',
+        allocation: [[0, 45]],
+    };
+
+    const validCohortV2: Cohort = {
+        name: 'test_cohort',
+        allocation: {
+            range: [[50, 100]],
+        },
+    };
+    const invalidCohortV2: Cohort = {
+        name: 'test_cohort',
+        allocation: {
+            range: [[0, 45]],
+        },
+    };
+    const fieldCohortV2: Cohort = {
+        name: 'test_cohort',
+        allocation: {
+            range: [[50, 100]],
+            fields: hashObject(
+                {
+                    email_domain: ['data.ai'],
+                },
+                salt
+            ),
+        },
+    };
+
+    it('passes an allocation if the user segment is within the valid range', () => {
+        expect(
+            validateAllocation(validCohort, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
+        ).toBe(true);
+    });
+    it('fails an allocation if the user segment is not within the valid range', () => {
+        expect(
+            validateAllocation(invalidCohort, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
+        ).toBe(false);
+    });
+    it('V2 - passes an allocation if the user segment is within the valid range', () => {
+        expect(
+            validateAllocation(validCohortV2, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
+        ).toBe(true);
+    });
+    it('V2 - fails an allocation if the user segment is not within the valid range', () => {
+        expect(
+            validateAllocation(invalidCohortV2, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
+        ).toBe(false);
+    });
+    it('V2 - passes an allocation with fields if the user satisfies field requirements', () => {
+        expect(
+            validateAllocation(
+                fieldCohortV2,
+                hashObject({ user_id: 2, email_domain: 'data.ai' }, salt),
+                'experiment_1',
+                2
+            )
+        ).toBe(true);
+    });
+    it('V2 - fails an allocation with fields if the user does not satisfy field requirements', () => {
+        expect(
+            validateAllocation(
+                fieldCohortV2,
+                hashObject({ user_id: 2, email_domain: 'google.ca' }, salt),
+                'experiment_1',
+                2
+            )
+        ).toBe(false);
+    });
+});

--- a/packages/ab-testing/__tests__/functions.test.ts
+++ b/packages/ab-testing/__tests__/functions.test.ts
@@ -12,29 +12,15 @@ describe('test validateAllocation func', () => {
         allocation: [[0, 45]],
     };
 
-    const validCohortV2: Cohort = {
-        name: 'test_cohort',
-        allocation: {
-            range: [[50, 100]],
-        },
-    };
-    const invalidCohortV2: Cohort = {
-        name: 'test_cohort',
-        allocation: {
-            range: [[0, 45]],
-        },
-    };
     const fieldCohortV2: Cohort = {
         name: 'test_cohort',
-        allocation: {
-            range: [[50, 100]],
-            fields: hashObject(
-                {
-                    email_domain: ['data.ai'],
-                },
-                salt
-            ),
-        },
+        allocation: [[50, 100]],
+        allocation_criteria: hashObject(
+            {
+                email_domain: ['data.ai'],
+            },
+            salt
+        ),
     };
 
     it('passes an allocation if the user segment is within the valid range', () => {
@@ -45,16 +31,6 @@ describe('test validateAllocation func', () => {
     it('fails an allocation if the user segment is not within the valid range', () => {
         expect(
             validateAllocation(invalidCohort, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
-        ).toBe(false);
-    });
-    it('V2 - passes an allocation if the user segment is within the valid range', () => {
-        expect(
-            validateAllocation(validCohortV2, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
-        ).toBe(true);
-    });
-    it('V2 - fails an allocation if the user segment is not within the valid range', () => {
-        expect(
-            validateAllocation(invalidCohortV2, hashObject({ user_id: 2 }, salt), 'experiment_1', 2)
         ).toBe(false);
     });
     it('V2 - passes an allocation with fields if the user satisfies field requirements', () => {

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -29,14 +29,13 @@ function getModuloValue(experiment: string, userId: number | string): number {
 }
 
 function validateCriteria(criteria: ForceInclude, userProfile: UserProfile): boolean {
-    let itemMatchesCriteria = true;
     for (const key in criteria) {
         if (!criteria[key].includes(userProfile[key])) {
-            itemMatchesCriteria = false;
+            return false;
         }
     }
 
-    return itemMatchesCriteria;
+    return true;
 }
 
 export function validateAllocation(
@@ -44,20 +43,18 @@ export function validateAllocation(
     userProfile: UserProfile,
     userSegmentNum: number
 ): boolean {
-    let withinRange = false,
-        fulfillsCriteria = true;
-    if (cohort.allocation) {
-        for (const allocation of cohort.allocation) {
-            withinRange = allocation[0] <= userSegmentNum && userSegmentNum < allocation[1];
+    let withinRange = false;
+    let fulfillsCriteria = true;
+    for (const allocation of cohort.allocation || []) {
+        withinRange = allocation[0] <= userSegmentNum && userSegmentNum < allocation[1];
 
-            if (withinRange) {
-                break;
-            }
+        if (withinRange) {
+            break;
         }
+    }
 
-        if (withinRange && cohort.allocation_criteria) {
-            fulfillsCriteria = validateCriteria(cohort.allocation_criteria, userProfile);
-        }
+    if (withinRange && cohort.allocation_criteria) {
+        fulfillsCriteria = validateCriteria(cohort.allocation_criteria, userProfile);
     }
 
     return withinRange && fulfillsCriteria;

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -30,7 +30,7 @@ function getModuloValue(experiment: string, userId: number | string): number {
     return crc32.calculate(String(userId), crc32.calculate(experiment)) % 100;
 }
 
-function validateAllocationFilters(filters: ForceInclude, userProfile: UserProfile): boolean {
+function validateAllocationCriteria(filters: ForceInclude, userProfile: UserProfile): boolean {
     let itemMatchesCriteria = true;
     for (const key in filters) {
         if (!filters[key].includes(userProfile[key])) {
@@ -61,7 +61,7 @@ export function validateAllocation(
     if (cohort.allocation) {
         if (validateUserWithinAllocationRange(userSegmentNum, cohort.allocation)) {
             if (cohort.allocation_criteria) {
-                return validateAllocationFilters(cohort.allocation_criteria, userProfile);
+                return validateAllocationCriteria(cohort.allocation_criteria, userProfile);
             }
             return true;
         }

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -54,9 +54,7 @@ const isAllocationV2 = (allocation: any): allocation is AllocationV2 =>
 
 function validateUserWithinAllocationRange(userSegmentNum: number, range: AllocationV1) {
     for (const allocation of range) {
-        console.log(userSegmentNum, allocation);
         if (allocation[0] <= userSegmentNum && userSegmentNum < allocation[1]) {
-            console.log('returning true');
             return true;
         }
     }

--- a/packages/ab-testing/src/index.ts
+++ b/packages/ab-testing/src/index.ts
@@ -49,8 +49,9 @@ function validateAllocationFields(fields: AllocationFields, userProfile: UserPro
     return itemMatchesCriteria;
 }
 
-const isAllocationV2 = (allocation: any): allocation is AllocationV2 =>
-    allocation.range !== undefined || allocation.fields !== undefined;
+const isAllocationV2 = (allocation: any): allocation is AllocationV2 => {
+    return allocation.range !== undefined;
+};
 
 function validateUserWithinAllocationRange(userSegmentNum: number, range: AllocationV1) {
     for (const allocation of range) {
@@ -73,7 +74,7 @@ export function validateAllocation(
         if (isAllocationV2(cohort.allocation)) {
             const range = cohort.allocation.range;
             const fields = cohort.allocation.fields;
-            if (validateUserWithinAllocationRange(userSegmentNum, range) || !range) {
+            if (validateUserWithinAllocationRange(userSegmentNum, range)) {
                 if (fields) {
                     return validateAllocationFields(fields, userProfile);
                 }


### PR DESCRIPTION
This PR adds an AllocationV2 to the AB testing schema.

This will allow users to enter an object with range and fields instead of just a range. The range and fields allows the allocation to do a further check before passing the test, which then filters out that the user's profile must match the fields before approving the cohort.