### PR TITLE
feat: python ab testing allocation criteria

### DIFF
--- a/packages/py-ab-testing/ABTesting/controller.py
+++ b/packages/py-ab-testing/ABTesting/controller.py
@@ -10,6 +10,12 @@ def get_modulo_value(experiment, user_id):
     # type: (str, Union[str, int]) -> int
     return crc32c(str(user_id).encode(), crc32c(experiment.encode())) % 100
 
+def validate_criteria(criteria, user_profile):
+    for key in criteria:
+        if not (key in user_profile and user_profile[key] in criteria[key]):
+            return False
+    
+    return True
 
 def match_user_cohort(
     experiment_config,
@@ -19,15 +25,23 @@ def match_user_cohort(
     # type: (Dict, Union[str, int], Dict[str, str]) -> str
     user_segment_num = get_modulo_value(experiment_config['name'], user_id)
     allocated_cohort = 'control'
+    within_allocation_range = False
+
     for cohort in experiment_config['cohorts']:
         for force_include_key, force_include_val in cohort.get('force_include', {}).items():
             if force_include_key in user_profile and user_profile[force_include_key] in force_include_val:
                 return cohort['name']
+
         if allocated_cohort == 'control':
             for allocation in cohort.get('allocation', []):
                 if allocation[0] <= user_segment_num < allocation[1]:
-                    allocated_cohort = cohort['name']
+                    within_allocation_range = True
                     break
+
+            if(within_allocation_range):
+                if(validate_criteria(cohort.get('allocation_criteria', []), user_profile)):
+                    allocated_cohort = cohort['name']
+
     return allocated_cohort
 
 

--- a/packages/py-ab-testing/ABTesting/controller.py
+++ b/packages/py-ab-testing/ABTesting/controller.py
@@ -39,7 +39,7 @@ def match_user_cohort(
                     break
 
             if(within_allocation_range):
-                if(validate_criteria(cohort.get('allocation_criteria', []), user_profile)):
+                if(validate_criteria(cohort.get('allocation_criteria', {}), user_profile)):
                     allocated_cohort = cohort['name']
 
     return allocated_cohort

--- a/packages/py-ab-testing/tests/test_controller.py
+++ b/packages/py-ab-testing/tests/test_controller.py
@@ -90,6 +90,21 @@ def config(salt):
                         }, salt)
                     },
                 ]
+            },
+            {
+                "name": "experiment_4",
+                "cohorts": [
+                    {
+                        "name": "control",
+                        "force_include": {}
+                    },
+                    {
+                        "name": "test_allocation",
+                        "allocation": [
+                            [40, 50]
+                        ],
+                    },
+                ]
             }
         ],
         "salt": salt
@@ -209,19 +224,33 @@ def test_match_cohort(config, salt, snapshot):
         1,
         hash_dict({'user_id': 1, 'email_domain': 'data2.ai'}, salt)
     ).get_cohort('experiment_3') == 'control'
+
+    # Experiment 4 - Test Allocation without Allocation Criteria
+
+    assert ABTestingController(
+        config,
+        1,
+        hash_dict({'user_id': 1, 'email_domain': 'data.ai'}, salt)
+    ).get_cohort('experiment_4') == 'test_allocation'
     
-    # Experiment 4 - non-existent cohort tests
+    assert ABTestingController(
+        config,
+        1234,
+        hash_dict({'user_id': 1234, 'email_domain': 'data2.ai'}, salt)
+    ).get_cohort('experiment_4') == 'control'
+    
+    # Experiment 5 - non-existent cohort tests
 
     assert ABTestingController(
         config,
         1,
         hash_dict({'user_id': 1, 'email_domain': 'example.com'}, salt)
-    ).get_cohort('experiment_4') == 'control'
+    ).get_cohort('experiment_5') == 'control'
     assert ABTestingController(
         config,
         1,
         hash_dict({'user_id': 1, 'email_domain': 'example.com'}, salt)
-    ).has_experiment('experiment_4') == False
+    ).has_experiment('experiment_5') == False
 
 
 def test_match_results_are_cached(config, salt):


### PR DESCRIPTION
This implements allocation criteria to python using the same logic as the JS equivalent.